### PR TITLE
Upgrade Python to 3.12

### DIFF
--- a/environment/default.nix
+++ b/environment/default.nix
@@ -11,7 +11,7 @@ pkgs: self:
 
   rocm = self.overrideScope (_: _: { platform = "rocm"; });
 
-  basePython = pkgs.python311;
+  basePython = pkgs.python312;
 
   poetry = pkgs.poetry.override {
     python3 = self.basePython;


### PR DESCRIPTION
According to the ComfyUI [Readme](https://github.com/comfyanonymous/ComfyUI?tab=readme-ov-file#manual-install-windows-linux) the new recommended Python version is 3.12. 

ComfyUI is pulling in a lot of duplicate dependencies due to the older Python version.